### PR TITLE
Parse config for colors

### DIFF
--- a/lua/feline/init.lua
+++ b/lua/feline/init.lua
@@ -34,6 +34,7 @@ function M.setup(config)
         preset = presets["default"]
     end
 
+    colors = parse_config(config, "colors", "table", {})
     colors.fg = parse_config(config, "default_fg", "string", colors.fg)
     colors.bg = parse_config(config, "default_bg", "string", colors.bg)
     vi_mode_colors = parse_config(config, "vi_mode_colors", "table", {})


### PR DESCRIPTION
Parse config for color override like for `vi_mode_color`

```lua
local colors = {
  bg = '#282828',
  black = '#282828',
  yellow = '#d8a657',
  cyan = '#89b482',
  oceanblue = '#45707a',
  green = '#a9b665',
  orange = '#e78a4e',
  violet = '#d3869b',
  magenta = '#c14a4a',
  white = '#a89984',
  fg = '#a89984',
  skyblue = '#7daea3',
  red = '#ea6962',
}
```