### PR TITLE
Fix lsp provider

### DIFF
--- a/lua/feline/providers/lsp.lua
+++ b/lua/feline/providers/lsp.lua
@@ -13,7 +13,7 @@ function M.get_diagnostics_count(severity)
     local active_clients = lsp.buf_get_clients(bufnr)
     local count = 0
 
-    for _, client in ipairs(active_clients) do
+    for _, client in pairs(active_clients) do
         count = count + lsp.diagnostic.get_count(bufnr, severity, client.id)
     end
 


### PR DESCRIPTION
The result of `vim.lsp.buf_get_clients()` should not be iterated by `ipairs`. See its [source](https://github.com/neovim/neovim/blob/26bd5a58dff1b920757f3bc010c2e8f9dbfc9d40/runtime/lua/vim/lsp.lua#L1432) in neovim/neovim.

This line

```lua
result[client_id] = client
```

If a user opens multiple buffers, `client_id` may not start from 1. If you iterate with `ipairs`, you will get an "empty table".

Change to `pairs` would fix it.