### PR TITLE
feat: default to `noicon` without "devicons"

### DIFF
--- a/lua/feline/init.lua
+++ b/lua/feline/init.lua
@@ -48,7 +48,12 @@ function M.setup(config)
     if parse_config(config, "preset", "string") then
         preset = presets[config.preset]
     else
-        preset = presets["default"]
+        local has_devicons = pcall(require,'nvim-web-devicons')
+        if has_devicons then
+            preset = presets["default"]
+        else
+            preset = presets["noicon"]
+        end
     end
 
     custom_colors = parse_config(config, "colors", "table", {})


### PR DESCRIPTION
Allows `feline` to run properly without any configuration when `nvim-web-devicons` is not installed

- defaults to the `noicon` when `nvim-web-devicons` is not present
- default stays at `default` when `nvim-web-devicons` is present

---

Based on discussions in #17 