### PR TITLE
fix for issue#23, feline makes splash screen disappear

### DIFF
--- a/lua/feline/init.lua
+++ b/lua/feline/init.lua
@@ -76,6 +76,19 @@ function M.setup(config)
     generator.components = components
     generator.properties = properties
 
+    -- fix for issue #23, according to:
+    -- https://github.com/powerline/powerline/issues/250
+    --  + Defining local value of &statusline option while
+    --    computing global value purges startup screen.
+    --  + Defining highlight group while computing statusline
+    --    purges startup screen.
+    -- The below calls will make sure all highlight groups
+    -- are already created and saved in `highlights` table
+    -- located at generator.lua#L33 so feline doesn't run
+    -- `highlight` commands as part of status line genration
+    gen.generate_statusline(true)
+    gen.generate_statusline(false)
+
     vim.o.statusline = '%!v:lua.require\'feline\'.statusline()'
 
     create_augroup({


### PR DESCRIPTION
This closes [issue #23](https://github.com/famiu/feline.nvim/issues/23).

[This comment in Powerline issue #250](https://github.com/powerline/powerline/issues/250#issuecomment-52275269) gave me the lead with:
```vim
" Hack to show startup screen. Problems in GUI:
" - Defining local value of &statusline option while computing global value 
"   purges startup screen.
" - Defining highlight group while computing statusline purges startup 
"   screen.
" This hack removes the “while computing statusline” part: both things are 
" defined, but they are defined right now.
```

I figured if I just call `generate_statusline` twice (`true|false`) this will generate all required `highlight` groups so that the `highlight` command isn't called as part of the initial `vim.o.statusline` generation:

```lua
    gen.generate_statusline(true)
    gen.generate_statusline(false)
```