### PR TITLE
Stop `vim.lsp` from loading eagerly

### DIFF
--- a/lua/feline/init.lua
+++ b/lua/feline/init.lua
@@ -40,7 +40,6 @@ function M.setup(config)
     local colors = require('feline.defaults').colors
     local separators = require('feline.defaults').separators
     local vi_mode = require('feline.providers.vi_mode')
-    local generator = require('feline.generator')
     local presets = require('feline.presets')
     local preset, components, properties
     local custom_colors, custom_separators, vi_mode_colors
@@ -73,8 +72,8 @@ function M.setup(config)
         vi_mode.mode_colors[k] = v
     end
 
-    generator.components = components
-    generator.properties = properties
+    gen.components = components
+    gen.properties = properties
 
     vim.o.statusline = '%!v:lua.require\'feline\'.statusline()'
 

--- a/lua/feline/providers/lsp.lua
+++ b/lua/feline/providers/lsp.lua
@@ -1,20 +1,18 @@
-local lsp = vim.lsp
-local get_current_buf = vim.api.nvim_get_current_buf
 local M = {}
 
 function M.is_lsp_attached()
-    return next(lsp.buf_get_clients()) ~= nil
+    return next(vim.lsp.buf_get_clients()) ~= nil
 end
 
 function M.get_diagnostics_count(severity)
     if not M.is_lsp_attached() then return nil end
 
-    local bufnr = get_current_buf()
-    local active_clients = lsp.buf_get_clients(bufnr)
+    local bufnr = vim.api.nvim_get_current_buf()
+    local active_clients = vim.lsp.buf_get_clients(bufnr)
     local count = 0
 
     for _, client in pairs(active_clients) do
-        count = count + lsp.diagnostic.get_count(bufnr, severity, client.id)
+        count = count + vim.lsp.diagnostic.get_count(bufnr, severity, client.id)
     end
 
     return count
@@ -29,7 +27,7 @@ function M.lsp_client_names(component)
     local clients = {}
     local icon = component.icon or ' '
 
-    for _, client in pairs(lsp.buf_get_clients()) do
+    for _, client in pairs(vim.lsp.buf_get_clients()) do
         clients[#clients+1] = icon .. client.name
     end
 


### PR DESCRIPTION
Before
```lua
...
require("feline.generator"): 3.6887ms (0.192100 -> 3.880800)
  require("feline.defaults"): 0.0656ms (0.337900 -> 0.403500)
  require("feline.defaults"): 0.0003ms (0.404700 -> 0.405000)
  require("feline.providers"): 3.4574ms (0.405400 -> 3.862800)
    require("feline.providers.vi_mode"): 0.0802ms (0.572700 -> 0.652900)
      require("feline.defaults"): 0.0005ms (0.650500 -> 0.651000)
    require("feline.providers.cursor"): 0.0683ms (0.653200 -> 0.721500)
    require("feline.providers.file"): 0.1017ms (0.722100 -> 0.823800)
    require("feline.providers.lsp"): 2.952ms (0.824300 -> 3.776300)
      require("vim.uri"): 0.0639ms (0.902300 -> 0.966200)
        require("bit"): 0.0003ms (0.965000 -> 0.965300)
      require("vim.lsp"): 2.8082ms (0.966500 -> 3.774700)
        require("vim.F"): 0.0251ms (1.439900 -> 1.465000)
        require("vim.lsp.handlers"): 1.3879ms (1.465900 -> 2.853800)
          require("vim.lsp.log"): 0.0781ms (1.630700 -> 1.708800)
          require("vim.lsp.protocol"): 0.3056ms (1.709400 -> 2.015000)
          require("vim.lsp.util"): 0.678ms (2.015600 -> 2.693600)
            require("vim.lsp.protocol"): 0.0005ms (2.623900 -> 2.624400)
            require("vim.highlight"): 0.0597ms (2.625000 -> 2.684700)
          require("vim.lsp.buf"): 0.1542ms (2.694200 -> 2.848400)
            require("vim.lsp.util"): 0.0004ms (2.844500 -> 2.844900)
        require("vim.lsp.log"): 0.0002ms (2.854400 -> 2.854600)
        require("vim.lsp.rpc"): 0.1967ms (2.854900 -> 3.051600)
          require("vim.lsp.log"): 0.0003ms (3.044600 -> 3.044900)
          require("vim.lsp.protocol"): 0.0003ms (3.045200 -> 3.045500)
        require("vim.lsp.protocol"): 0.0002ms (3.051900 -> 3.052100)
        require("vim.lsp.util"): 0.0002ms (3.052200 -> 3.052400)
        require("vim.lsp.buf"): 0.0002ms (3.052800 -> 3.053000)
        require("vim.lsp.diagnostic"): 0.4387ms (3.053200 -> 3.491900)
          require("vim.uri"): 0.0005ms (3.474400 -> 3.474900)
          require("vim.highlight"): 0.0002ms (3.475400 -> 3.475600)
          require("vim.lsp.log"): 0.0001ms (3.476100 -> 3.476200)
          require("vim.lsp.protocol"): 0.0001ms (3.476500 -> 3.476600)
          require("vim.lsp.util"): 0.0002ms (3.476800 -> 3.477000)
        require("vim.lsp.codelens"): 0.1058ms (3.492300 -> 3.598100)
          require("vim.lsp.util"): 0.0003ms (3.596400 -> 3.596700)
        require("vim.lsp.diagnostic"): 0.0003ms (3.617800 -> 3.618100)
    require("feline.providers.git"): 0.0835ms (3.777300 -> 3.860800)
...
```

After
```lua
...
require("feline.generator"): 0.7879ms (0.188900 -> 0.976800)
  require("feline.defaults"): 0.0655ms (0.334600 -> 0.400100)
  require("feline.defaults"): 0.0003ms (0.401300 -> 0.401600)
  require("feline.providers"): 0.5507ms (0.401900 -> 0.952600)
    require("feline.providers.vi_mode"): 0.0774ms (0.555000 -> 0.632400)
      require("feline.defaults"): 0.0003ms (0.630300 -> 0.630600)
    require("feline.providers.cursor"): 0.0682ms (0.632700 -> 0.700900)
    require("feline.providers.file"): 0.1012ms (0.701400 -> 0.802600)
    require("feline.providers.lsp"): 0.0771ms (0.803100 -> 0.880200)
    require("feline.providers.git"): 0.0687ms (0.880700 -> 0.949400)
...
```

This reduces the require for `feline.generator` by almost 3ms and this on my beefy setup, so it will have a more noticable difference on slower machines.