### PR TITLE
Add icon field to all components

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ enabled = function()
 end
 ```
 
-- `icon` (table or string): Some inbuilt providers like `git_branch`, provide default icons. If you either don't have a patched font or don't like the default icon that Feline provides, you may set this value to use any icon you want instead. Additionally, you can also change the highlight specifically for the icon. To do this you need to pass a table containing `str` and `hl`, where `str` would represent the icon and `hl` would represent the icon highlight. The icons's highlight works just like the `hl` component's values. For example:
+- `icon` (table or string): Some inbuilt providers such as `git_branch` provide default icons. If you either don't have a patched font or don't like the default icon that Feline provides, you may set this value to use any icon you want instead. By default, the icon inherits the component's highlight, but you can also change the highlight specifically for the icon. To do this, you need to pass a table containing `str` and `hl`, where `str` would represent the icon and `hl` would represent the icon highlight. The icons's highlight works just like the `hl` component's values. For example:
 
 ```lua
 -- Setting icon to a string

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ enabled = function()
 end
 ```
 
-- `icon` (string): Some components use a glyph icon. If you either don't have a patched font or don't like the default icon that Feline provides, you may set this value to use any icon you want instead. For example:
+- `icon` (table or string): Some inbuilt providers like `git_branch`, provide default icons. If you either don't have a patched font or don't like the default icon that Feline provides, you may set this value to use any icon you want instead. Additionally, you can also change the highlight specifically for the icon. To do this you need to pass a table containing `str` and `hl`, where `str` would represent the icon and `hl` would represent the icon highlight. The icons's highlight works just like the `hl` component's values. For example:
 
 ```lua
 -- Setting icon to a string
@@ -252,6 +252,12 @@ icon = ' + '
 
 -- Setting icon to a function
 icon = function() return ' - ' end
+
+-- Setting icon to a table
+icon = {
+    str = ' ~ ',
+    hi = { fg = 'orange' },
+}
 ```
 
 - `hl` (table or string): Determines the highlight settings.<br>

--- a/lua/feline/providers/file.lua
+++ b/lua/feline/providers/file.lua
@@ -99,7 +99,7 @@ function M.file_info(component)
         modified_str = ''
     end
 
-    return icon .. ' ' .. filename .. ' ' .. modified_str
+    return ' ' .. filename .. ' ' .. modified_str, icon
 end
 
 function M.file_size()

--- a/lua/feline/providers/git.lua
+++ b/lua/feline/providers/git.lua
@@ -3,45 +3,57 @@ local M = {}
 function M.git_branch(component)
     local gsd = vim.b.gitsigns_status_dict
 
+    local icon
+    local str = ''
+
     if gsd and gsd.head and #gsd.head > 0 then
-        local icon = component.icon or '  '
-        return icon .. gsd.head
-    else
-        return ''
+        icon = component.icon or ' '
+        str = str .. gsd.head
     end
+
+    return str, icon
 end
 
 function M.git_diff_added(component)
     local gsd = vim.b.gitsigns_status_dict
 
+    local icon
+    local str = ''
+
     if gsd and gsd['added'] and gsd['added'] > 0 then
-        local icon = component.icon or '  '
-        return icon .. gsd.added
-    else
-        return ''
+        icon = component.icon or '  '
+        str = str .. gsd.added
     end
+
+    return str, icon
 end
 
 function M.git_diff_removed(component)
     local gsd = vim.b.gitsigns_status_dict
 
+    local icon
+    local str = ''
+
     if gsd and gsd['removed'] and gsd['removed'] > 0 then
-        local icon = component.icon or '  '
-        return icon .. gsd.removed
-    else
-        return ''
+        icon = component.icon or '  '
+        str = str .. gsd.removed
     end
+
+    return str, icon
 end
 
 function M.git_diff_changed(component)
     local gsd = vim.b.gitsigns_status_dict
 
+    local icon
+    local str = ''
+
     if gsd and gsd['changed'] and gsd['changed'] > 0 then
-        local icon = component.icon or ' 柳'
-        return icon .. gsd.changed
-    else
-        return ''
+        icon = component.icon or ' 柳 '
+        str = str .. gsd.changed
     end
+
+    return str, icon
 end
 
 return M

--- a/lua/feline/providers/lsp.lua
+++ b/lua/feline/providers/lsp.lua
@@ -33,23 +33,23 @@ function M.lsp_client_names(component)
         clients[#clients+1] = icon .. client.name
     end
 
-    return table.concat(clients, ' ')
+    return table.concat(clients, ' '), nil
 end
 
 function M.diagnostic_errors(component)
-    return (component.icon or '  ') .. M.get_diagnostics_count('Error')
+    return '' .. M.get_diagnostics_count('Error'), (component.icon or '  ')
 end
 
 function M.diagnostic_warnings(component)
-    return (component.icon or '  ') .. M.get_diagnostics_count('Warning')
+    return '' .. M.get_diagnostics_count('Warning'), (component.icon or '  ')
 end
 
 function M.diagnostic_hints(component)
-    return (component.icon or '  ') .. M.get_diagnostics_count('Hint')
+    return '' .. M.get_diagnostics_count('Error'), (component.icon or '  ')
 end
 
 function M.diagnostic_info(component)
-    return (component.icon or '  ') .. M.get_diagnostics_count('Information')
+    return '' .. M.get_diagnostics_count('Information'), (component.icon or '  ')
 end
 
 return M

--- a/lua/feline/providers/lsp.lua
+++ b/lua/feline/providers/lsp.lua
@@ -2,15 +2,11 @@ local lsp = vim.lsp
 local get_current_buf = vim.api.nvim_get_current_buf
 local M = {}
 
-function M.is_lsp_attached()
-    return next(lsp.buf_get_clients()) ~= nil
-end
-
 function M.get_diagnostics_count(severity)
-    if not M.is_lsp_attached() then return nil end
-
     local bufnr = get_current_buf()
     local active_clients = lsp.buf_get_clients(bufnr)
+    if not active_clients then return nil end
+
     local count = 0
 
     for _, client in pairs(active_clients) do
@@ -30,26 +26,34 @@ function M.lsp_client_names(component)
     local icon = component.icon or ' '
 
     for _, client in pairs(lsp.buf_get_clients()) do
-        clients[#clients+1] = icon .. client.name
+        clients[#clients+1] = client.name
     end
 
-    return table.concat(clients, ' '), nil
+    return table.concat(clients, ' '), icon
 end
 
 function M.diagnostic_errors(component)
-    return '' .. M.get_diagnostics_count('Error'), (component.icon or '  ')
+    local count = M.get_diagnostics_count('Error')
+    if not count or count == 0 then return '' end
+    return tostring(count), (component.icon or '  ')
 end
 
 function M.diagnostic_warnings(component)
-    return '' .. M.get_diagnostics_count('Warning'), (component.icon or '  ')
+    local count = M.get_diagnostics_count('Warning')
+    if not count or count == 0 then return '' end
+    return tostring(count), (component.icon or '  ')
 end
 
 function M.diagnostic_hints(component)
-    return '' .. M.get_diagnostics_count('Error'), (component.icon or '  ')
+    local count = M.get_diagnostics_count('Hint')
+    if not count or count == 0 then return '' end
+    return tostring(count), (component.icon or '  ')
 end
 
 function M.diagnostic_info(component)
-    return '' .. M.get_diagnostics_count('Information'), (component.icon or '  ')
+    local count = M.get_diagnostics_count('Information')
+    if not count or count == 0 then return '' end
+    return tostring(count), (component.icon or '  ')
 end
 
 return M


### PR DESCRIPTION
Closes #28

I took a stab at trying add `icon` as field for any component. Due to the fact that the builtin providers have fallback icons, I needed to introduce an optional return value for all builtin providers. This was probably the easiest solution that wouldn't require refactoring how providers work in feline. 

Additionally, `icon` can accept a table. The fields accepted are exactly the same as the fields accepted for the separators.

I also refactored  some of the LSP providers. `lsp_client_names` no longer has an icon after every attached client so it can benefit from the new fields added to `icon`. `diagnostic_`* functions now check if LSP is attached or if no diagnostics are available.

I tested all the builtin providers and so far everything works as expected. I will add docs once the PR is reviewed.