### PR TITLE
Remove extra space in `git_diff_changed` provider

### DIFF
--- a/lua/feline/providers/git.lua
+++ b/lua/feline/providers/git.lua
@@ -49,7 +49,7 @@ function M.git_diff_changed(component)
     local str = ''
 
     if gsd and gsd['changed'] and gsd['changed'] > 0 then
-        icon = component.icon or ' 柳 '
+        icon = component.icon or ' 柳'
         str = str .. gsd.changed
     end
 


### PR DESCRIPTION
`\uf9c9` (the default icon of `git_diff_changed` provider) in nerd font is larger (2 spaces) than it is expected (1 space). It can be confirmed in kitty, konsole, and hyper.

This makes it looks weird in terminal.
I don't know why, but I removed a trailing space to make it look good.

Before:

![image](https://user-images.githubusercontent.com/39000776/131489335-e2ec79f0-4d70-4f9a-b55c-d692d6b5b6c9.png)

After:

![image](https://user-images.githubusercontent.com/39000776/131489418-82f94e63-8877-4bb9-810a-80464c542b42.png)
