### PR TITLE
Fix highlight background for `file_info`

### DIFF
--- a/lua/feline/providers/file.lua
+++ b/lua/feline/providers/file.lua
@@ -90,7 +90,8 @@ function M.file_info(component)
     local icon = component.icon
     if not icon then
         local ic, hl_group = require("nvim-web-devicons").get_icon(filename, extension, { default = true })
-        icon = { str = ic, hl = hl_group }
+        local fg = fn.synIDattr(fn.synIDtrans(fn.hlID(hl_group)), "fg")
+        icon = { str = ic, hl = {fg = fg} }
     end
 
     if filename == '' then filename = 'unnamed' end


### PR DESCRIPTION
I've found a new bug introduced in #38 . The file icon's background color automatically turns blacker with Normal when my feed background color is light.
before version:
![front](https://user-images.githubusercontent.com/57695072/131606737-4902c1a4-57d0-461c-bcf9-d2f6b8250a12.png)
fixed version:
![fixed](https://user-images.githubusercontent.com/57695072/131607254-4253d54d-15f6-4999-bd7d-afb3e4f85501.png)
