### PR TITLE
perf(providers): reduce `vim.fn` calls

### DIFF
--- a/lua/feline/providers/cursor.lua
+++ b/lua/feline/providers/cursor.lua
@@ -1,21 +1,21 @@
-local fn = vim.fn
+local api = vim.api
 
 local M = {}
 
 function M.position()
-    return string.format('%3d:%-2d', fn.line('.'), fn.col('.'))
+    return "%3l:%-2c"
 end
 
 function M.line_percentage()
-    local curr_line = fn.line('.')
-    local lines = fn.line('$')
+    local curr_line = api.nvim_win_get_cursor(0)[1]
+    local lines = api.nvim_buf_line_count(0)
 
     if curr_line == 1 then
         return "Top"
     elseif curr_line == lines then
         return "Bot"
     else
-        return string.format('%2d%%%%', fn.round(curr_line / lines * 100))
+        return "%3p%%"
     end
 end
 
@@ -23,10 +23,10 @@ function M.scroll_bar()
     local blocks =  {'▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'}
     local width = 2
 
-    local curr_line = fn.line('.')
-    local lines = fn.line('$')
+    local curr_line = api.nvim_win_get_cursor(0)[1]
+    local lines = api.nvim_buf_line_count(0)
 
-    local index = fn.floor(curr_line / lines * (#blocks - 1)) + 1
+    local index = math.floor(curr_line / lines * (#blocks - 1)) + 1
 
     return string.rep(blocks[index], width)
 end

--- a/lua/feline/providers/file.lua
+++ b/lua/feline/providers/file.lua
@@ -66,13 +66,13 @@ function M.file_info(component)
     component.type = component.type or 'base-only'
 
     if component.type == 'full-path' then
-        filename = fn.expand('%:p')
+        filename = '%F'
     elseif component.type == 'short-path' then
         filename = fn.pathshorten(fn.expand('%:p'))
     elseif component.type == 'base-only' then
-        filename = fn.expand('%:t')
+        filename = '%t'
     elseif component.type == 'relative' then
-        filename = fn.fnamemodify(fn.expand("%"), ":~:.")
+        filename = '%f'
     elseif component.type == 'relative-short' then
         filename = fn.pathshorten(fn.fnamemodify(fn.expand("%"), ":~:."))
     elseif component.type == 'unique' then
@@ -82,7 +82,6 @@ function M.file_info(component)
     else
         filename = fn.expand('%:t')
     end
-
 
     local extension = fn.expand('%:e')
     local modified_str

--- a/lua/feline/providers/vi_mode.lua
+++ b/lua/feline/providers/vi_mode.lua
@@ -1,61 +1,62 @@
-local fn = vim.fn
+local api = vim.api
 local colors = require('feline.defaults').colors
 
 local M = {}
 
 local mode_alias = {
-    n = 'NORMAL',
-    no = 'OP',
-    nov = 'OP',
-    noV = 'OP',
+    ['n'] = 'NORMAL',
+    ['no'] = 'OP',
+    ['nov'] = 'OP',
+    ['noV'] = 'OP',
     ['no'] = 'OP',
-    niI = 'NORMAL',
-    niR = 'NORMAL',
-    niV = 'NORMAL',
-    v = 'VISUAL',
-    V = 'VISUAL',
+    ['niI'] = 'NORMAL',
+    ['niR'] = 'NORMAL',
+    ['niV'] = 'NORMAL',
+    ['v'] = 'VISUAL',
+    ['V'] = 'VISUAL',
     [''] = 'BLOCK',
-    s = 'SELECT',
-    S = 'SELECT',
+    ['s'] = 'SELECT',
+    ['S'] = 'SELECT',
     [''] = 'BLOCK',
-    i = 'INSERT',
-    ic = 'INSERT',
-    ix = 'INSERT',
-    R = 'REPLACE',
-    Rc = 'REPLACE',
-    Rv = 'V-REPLACE',
-    Rx = 'REPLACE',
-    c = 'COMMAND',
-    cv = 'COMMAND',
-    ce = 'COMMAND',
-    r = 'ENTER',
-    rm = 'MORE',
+    ['i'] = 'INSERT',
+    ['ic'] = 'INSERT',
+    ['ix'] = 'INSERT',
+    ['R'] = 'REPLACE',
+    ['Rc'] = 'REPLACE',
+    ['Rv'] = 'V-REPLACE',
+    ['Rx'] = 'REPLACE',
+    ['c'] = 'COMMAND',
+    ['cv'] = 'COMMAND',
+    ['ce'] = 'COMMAND',
+    ['r'] = 'ENTER',
+    ['rm'] = 'MORE',
     ['r?'] = 'CONFIRM',
     ['!'] = 'SHELL',
-    t = 'TERM',
+    ['t'] = 'TERM',
     ['null'] = 'NONE',
 }
 
 M.mode_colors = {
-    NORMAL = colors.green,
-    OP = colors.green,
-    INSERT = colors.red,
-    VISUAL = colors.skyblue,
-    BLOCK = colors.skyblue,
-    REPLACE = colors.violet,
+    ['NORMAL'] = colors.green,
+    ['OP'] = colors.green,
+    ['INSERT'] = colors.red,
+    ['VISUAL'] = colors.skyblue,
+    ['BLOCK'] = colors.skyblue,
+    ['REPLACE'] = colors.violet,
     ['V-REPLACE'] = colors.violet,
-    ENTER = colors.cyan,
-    MORE = colors.cyan,
-    SELECT = colors.orange,
-    COMMAND = colors.green,
-    SHELL = colors.green,
-    TERM = colors.green,
-    NONE = colors.yellow
+    ['ENTER'] = colors.cyan,
+    ['MORE'] = colors.cyan,
+    ['SELECT'] = colors.orange,
+    ['COMMAND'] = colors.green,
+    ['SHELL'] = colors.green,
+    ['TERM'] = colors.green,
+    ['NONE'] = colors.yellow
 }
 
 -- Functions for statusline
 function M.get_vim_mode()
-    return mode_alias[fn.mode()]
+    local mode = api.nvim_get_mode().mode
+    return mode_alias[mode]
 end
 
 function M.get_mode_color()


### PR DESCRIPTION
https://github.com/famiu/feline.nvim/pull/40#issuecomment-909975582 inspired me to replace as many `vim.fn` calls with either `vim.api` functions or vim statusline items (see http://vimdoc.sourceforge.net/htmldoc/options.html#'statusline').