### PR TITLE
feat(file_info): add `colored_icon` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -918,7 +918,9 @@ The Vi-mode provider also provides a helper function `get_mode_highlight_name()`
 
 #### File Info
 
-The `file_info` provider has two special component values:
+The `file_info` provider has three special component values:
+- `colored_icon` (boolean): Determines whether file icon should use color inherited from `nvim-web-devicons`.<br>
+Default:`false`
 - `file_modified_icon` (string): The icon that is shown when a file is modified.<br>
 Default:`'●'`
 - `type` (string): Determines which parts of the filename are shown. Its value can be one of:

--- a/README.md
+++ b/README.md
@@ -920,7 +920,7 @@ The Vi-mode provider also provides a helper function `get_mode_highlight_name()`
 
 The `file_info` provider has three special component values:
 - `colored_icon` (boolean): Determines whether file icon should use color inherited from `nvim-web-devicons`.<br>
-Default:`false`
+Default: `true`
 - `file_modified_icon` (string): The icon that is shown when a file is modified.<br>
 Default:`'●'`
 - `type` (string): Determines which parts of the filename are shown. Its value can be one of:

--- a/lua/feline/presets/default.lua
+++ b/lua/feline/presets/default.lua
@@ -74,7 +74,7 @@ M.components.left.active[3] = {
         ' ', 'slant_left_2',
         {str = ' ', hl = {bg = 'oceanblue', fg = 'NONE'}}
     },
-    right_sep = {'slant_right_2', ' '},
+    right_sep = {'slant_right_2', ' '}
 }
 
 M.components.left.active[4] = {

--- a/lua/feline/presets/default.lua
+++ b/lua/feline/presets/default.lua
@@ -75,7 +75,6 @@ M.components.left.active[3] = {
         {str = ' ', hl = {bg = 'oceanblue', fg = 'NONE'}}
     },
     right_sep = {'slant_right_2', ' '},
-    colored_icon = true,
 }
 
 M.components.left.active[4] = {

--- a/lua/feline/presets/default.lua
+++ b/lua/feline/presets/default.lua
@@ -74,7 +74,8 @@ M.components.left.active[3] = {
         ' ', 'slant_left_2',
         {str = ' ', hl = {bg = 'oceanblue', fg = 'NONE'}}
     },
-    right_sep = {'slant_right_2', ' '}
+    right_sep = {'slant_right_2', ' '},
+    colored_icon = true,
 }
 
 M.components.left.active[4] = {

--- a/lua/feline/providers/file.lua
+++ b/lua/feline/providers/file.lua
@@ -89,10 +89,12 @@ function M.file_info(component)
     local icon = component.icon
     if not icon then
         local ic, hl_group = require("nvim-web-devicons").get_icon(filename, extension, { default = true })
-        local fg = vim.api.nvim_get_hl_by_name(hl_group, true)['foreground']
         icon = { str = ic }
-        if fg then
-          icon["hl"] = { fg = string.format('#%06x', fg) }
+        if component.colored_icon then
+            local fg = vim.api.nvim_get_hl_by_name(hl_group, true)['foreground']
+            if fg then
+                icon["hl"] = { fg = string.format('#%06x', fg) }
+            end
         end
     end
 

--- a/lua/feline/providers/file.lua
+++ b/lua/feline/providers/file.lua
@@ -89,8 +89,17 @@ function M.file_info(component)
     local icon = component.icon
     if not icon then
         local ic, hl_group = require("nvim-web-devicons").get_icon(filename, extension, { default = true })
+        local colored_icon
+        
+        if component.colored_icon == nil then
+            colored_icon = true
+        else
+            colored_icon = component.colored_icon
+        end
+        
         icon = { str = ic }
-        if component.colored_icon then
+
+        if colored_icon then
             local fg = vim.api.nvim_get_hl_by_name(hl_group, true)['foreground']
             if fg then
                 icon["hl"] = { fg = string.format('#%06x', fg) }


### PR DESCRIPTION
https://github.com/famiu/feline.nvim/issues/37#issuecomment-909849267 wasn't a fan of colored icons by default, so perhaps this should be behind a setting. I am wondering if it should be the default behaviour though, and instead allow the user to disable the colored icons if they want to.