### PR TITLE
file_size: bytes are shown without decimal digits

### DIFF
--- a/lua/feline/providers/file.lua
+++ b/lua/feline/providers/file.lua
@@ -119,7 +119,7 @@ function M.file_size()
         index = index + 1
     end
 
-    return string.format('%.2f', fsize) .. suffix[index]
+    return string.format(index == 1 and '%g' or '%.2f', fsize) .. suffix[index]
 end
 
 function M.file_type()


### PR DESCRIPTION
Byte value is shown without decimal digits because it's an integer number