### PR TITLE
Initialize left, mid and right section of components

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ So first, in your init.lua file, you have to initialize the components table
 ```lua
 -- Initialize the components table
 local components = {
-    active = {},
-    inactive = {}
+    active = {{}, {}, {}},
+    inactive = {{}, {}, {}}
 }
 ```
 


### PR DESCRIPTION
Initialize left, mid and right components

Using the table.insert way of adding components, something like
`table.insert(components.active[1], { -- stuff -- })`
would throw "attempt to index nil" error if the tables are not initialized before hand

The new format is working fine for me :)