### PR TITLE
fix: ensure config keys exist

### DIFF
--- a/lua/feline/init.lua
+++ b/lua/feline/init.lua
@@ -24,10 +24,8 @@ local function parse_config(config_dict, config_name, expected_type, default_val
                 expected_type, config_name, type(config_dict[config_name])
             )
         end
-    elseif default_value then
-        return default_value
     else
-        return nil
+        return default_value
     end
 end
 
@@ -92,10 +90,11 @@ function M.setup(config)
         end
     end
 
+    local components = parse_config(config, 'components', 'table')
 
-    local preset
-    if config and parse_config(config, 'components', 'table') then
+    if config then
         local properties = parse_config(config, 'properties', 'table')
+
         if properties then
             -- Deprecation warning for the `properties` table
             api.nvim_echo(
@@ -127,23 +126,23 @@ function M.setup(config)
                 true, {}
             )
         end
-        preset = config
-    else
+    end
+
+    if not components then
         local presets = require('feline.presets')
-        if parse_config(config, 'preset', 'string') then
-            preset = presets[config.preset]
+
+        if parse_config(config, 'preset', 'string') and presets[config.preset] then
+            components = presets[config.preset].components
         else
             local has_devicons = pcall(require,'nvim-web-devicons')
 
             if has_devicons then
-                preset = presets['default']
+                components = presets['default'].components
             else
-                preset = presets['noicon']
+                components = presets['noicon'].components
             end
         end
     end
-
-    local components = parse_config(config, 'components', 'table', preset.components)
 
     -- Deprecation warning for old component format
     if not (components.active and components.inactive) then

--- a/lua/feline/init.lua
+++ b/lua/feline/init.lua
@@ -71,8 +71,6 @@ function M.setup(config)
     end
 
     local defaults = require('feline.defaults')
-    local presets = require('feline.presets')
-    local preset, components
 
     -- Configuration options
     local config_opts = {
@@ -94,52 +92,58 @@ function M.setup(config)
         end
     end
 
-    if config.properties then
-        -- Deprecation warning for the `properties` table
-        api.nvim_echo(
-            {{
-                '\nDeprecation warning:\n' ..
-                'The `properties` table for Feline has been deprecated and support for it ' ..
-                'will be removed soon. Please put the `force_inactive` table directly ' ..
-                'inside the setup function instead',
 
-                'WarningMsg'
-            }},
-            true, {}
-        )
+    local preset
+    if config and parse_config(config, 'components', 'table') then
+        local properties = parse_config(config, 'properties', 'table')
+        if properties then
+            -- Deprecation warning for the `properties` table
+            api.nvim_echo(
+                {{
+                    '\nDeprecation warning:\n' ..
+                    'The `properties` table for Feline has been deprecated and support for it ' ..
+                    'will be removed soon. Please put the `force_inactive` table directly ' ..
+                    'inside the setup function instead',
 
-        local properties = parse_config(config, 'properties', 'table', {})
-        M.force_inactive = properties.force_inactive
-    end
+                    'WarningMsg'
+                }},
+                true, {}
+            )
 
-    -- Deprecation warning for `default_fg` and `default_bg`
-    if config.default_fg or config.default_bg then
-        api.nvim_echo(
-            {{
-                '\nDeprecation warning:\n' ..
-                'The setup options `default_fg` and `default_bg` for Feline have been ' ..
-                'removed and no longer work. Please use the `fg` and `bg` values ' ..
-                'of the `colors` table instead.\n',
+            M.force_inactive = properties.force_inactive
+        end
 
-                'WarningMsg'
-            }},
-            true, {}
-        )
-    end
+        -- Deprecation warning for `default_fg` and `default_bg`
+        if config.default_fg or config.default_bg then
+            api.nvim_echo(
+                {{
+                    '\nDeprecation warning:\n' ..
+                    'The setup options `default_fg` and `default_bg` for Feline have been ' ..
+                    'removed and no longer work. Please use the `fg` and `bg` values ' ..
+                    'of the `colors` table instead.\n',
 
-    if parse_config(config, 'preset', 'string') then
-        preset = presets[config.preset]
+                    'WarningMsg'
+                }},
+                true, {}
+            )
+        end
+        preset = config
     else
-        local has_devicons = pcall(require,'nvim-web-devicons')
-
-        if has_devicons then
-            preset = presets['default']
+        local presets = require('feline.presets')
+        if parse_config(config, 'preset', 'string') then
+            preset = presets[config.preset]
         else
-            preset = presets['noicon']
+            local has_devicons = pcall(require,'nvim-web-devicons')
+
+            if has_devicons then
+                preset = presets['default']
+            else
+                preset = presets['noicon']
+            end
         end
     end
 
-    components = parse_config(config, 'components', 'table', preset.components)
+    local components = parse_config(config, 'components', 'table', preset.components)
 
     -- Deprecation warning for old component format
     if not (components.active and components.inactive) then


### PR DESCRIPTION
Current master doesn't work when you run `require('feline').setup()` because of the depreciation warnings. I have also moved `require('feline.presets')` to stop it from eagerly loading when a custom config is being used. 

I have tested all the three variations of setup (https://github.com/famiu/feline.nvim/tree/master#1-using-default-statusline) and tested my own config.