### PR TITLE
fix: make disable inherit correct table

### DIFF
--- a/lua/feline/init.lua
+++ b/lua/feline/init.lua
@@ -95,7 +95,7 @@ function M.setup(config)
     end
 
     M.force_inactive = parse_config(config, 'force_inactive', 'table', defaults.force_inactive)
-    M.disable = parse_config(config, 'force_inactive', 'table', defaults.disable)
+    M.disable = parse_config(config, 'disable', 'table', defaults.disable)
     M.update_triggers = defaults.update_triggers
 
     for _, trigger in ipairs(parse_config(config, 'update_triggers', 'table', {})) do


### PR DESCRIPTION
If you have a custom `force_inactive` table defined, it will instead disable the statusline for the respective files/buffers.