### PR TITLE
feat: add omit_empty key to separators

### DIFF
--- a/lua/feline/generator.lua
+++ b/lua/feline/generator.lua
@@ -108,7 +108,7 @@ end
 -- Parse component seperator
 -- By default, foreground color of separator is background color of parent
 -- and background color is set to default background color
-local function parse_sep(sep, parent_bg)
+local function parse_sep(sep, parent_bg, empty_provider)
     if sep == nil then return '' end
 
     local hl
@@ -119,6 +119,7 @@ local function parse_sep(sep, parent_bg)
         hl = {fg = parent_bg, bg = colors.bg}
     else
         sep = evaluate_if_function(sep)
+        if sep.omit_empty and empty_provider then return '' end
         str = sep.str or ''
         hl = evaluate_if_function(sep.hl) or {fg = parent_bg, bg = colors.bg}
     end
@@ -129,7 +130,7 @@ local function parse_sep(sep, parent_bg)
 end
 
 -- Either parse a single separator or a list of separators with different highlights
-local function parse_sep_list(sep_list, parent_bg)
+local function parse_sep_list(sep_list, parent_bg, empty_provider)
     if sep_list == nil then return '' end
 
     if (type(sep_list) == "table" and sep_list[1] and
@@ -137,12 +138,12 @@ local function parse_sep_list(sep_list, parent_bg)
         local sep_strs = {}
 
         for _,v in ipairs(sep_list) do
-            sep_strs[#sep_strs+1] = parse_sep(v, parent_bg)
+            sep_strs[#sep_strs+1] = parse_sep(v, parent_bg, empty_provider)
         end
 
         return table.concat(sep_strs)
     else
-        return parse_sep(sep_list, parent_bg)
+        return parse_sep(sep_list, parent_bg, empty_provider)
     end
 end
 
@@ -192,14 +193,15 @@ local function parse_component(component, winid)
 
     local hl = evaluate_if_function(component.hl, {})
 
-    local left_sep_str = parse_sep_list(component.left_sep, hl.bg)
-    local right_sep_str = parse_sep_list(component.right_sep, hl.bg)
-
     local str, icon = parse_provider(component.provider, component, winid)
+
+    local empty_provider = str == ''
+    local left_sep_str = parse_sep_list(component.left_sep, hl.bg, empty_provider)
+    local right_sep_str = parse_sep_list(component.right_sep, hl.bg, empty_provider)
 
     local hlname = parse_hl(hl)
 
-    if icon == nil and str ~= '' then
+    if icon == nil and empty_provder == false then
         icon = component.icon
     end
 


### PR DESCRIPTION
Ref: #71

I was also using similar workarounds as the issue's author and think this a reasonable use case. Not sure about the name of the key though. Let me know if you have suggestions before I go ahead and add the proper documentation (function comment and README).