### PR TITLE
fix: ensure that parent_bg has a value

### DIFF
--- a/lua/feline/generator.lua
+++ b/lua/feline/generator.lua
@@ -209,8 +209,8 @@ local function parse_component(component, winid)
 
     local is_component_empty = str == ''
 
-    local left_sep_str = parse_sep_list(component.left_sep, hl.bg, is_component_empty)
-    local right_sep_str = parse_sep_list(component.right_sep, hl.bg, is_component_empty)
+    local left_sep_str = parse_sep_list(component.left_sep, hl.bg or colors.bg, is_component_empty)
+    local right_sep_str = parse_sep_list(component.right_sep, hl.bg or colors.bg, is_component_empty)
 
     local hlname = parse_hl(hl)
 


### PR DESCRIPTION
Closes: #23

`parent_bg` can be `nil`, which resulted in the the splash screen bug.

cc: @ibhagwan @famiu