### PR TITLE
refactor: separate provider options from component values

### DIFF
--- a/lua/feline/generator.lua
+++ b/lua/feline/generator.lua
@@ -224,7 +224,7 @@ local function parse_provider(provider, winid, component)
         provider, icon = providers[provider](winid, component, opts)
     -- If provider is a function, just evaluate it normally
     elseif type(provider) == "function" then
-        provider, icon = provider(winid, component, opts)
+        provider, icon = provider(winid, component)
     -- If provider is a table, get the provider name and opts and evaluate the provider
     elseif type(provider) == "table" then
         opts = provider.opts

--- a/lua/feline/generator.lua
+++ b/lua/feline/generator.lua
@@ -215,13 +215,20 @@ local function parse_icon(icon, parent_hl, is_component_empty)
 end
 
 -- Parse component provider
-local function parse_provider(provider, component, winid)
+local function parse_provider(provider, winid, component)
     local icon
+    local opts = {}
 
-    if type(provider) == "string" and type(providers[provider]) == "function" then
-        provider, icon = providers[provider](component, winid)
+    -- If provider is a string and its name matches the name of a registered provider, use it
+    if type(provider) == "string" and providers[provider] then
+        provider, icon = providers[provider](winid, component, opts)
+    -- If provider is a function, just evaluate it normally
     elseif type(provider) == "function" then
-        provider, icon = provider(component, winid)
+        provider, icon = provider(winid, component, opts)
+    -- If provider is a table, get the provider name and opts and evaluate the provider
+    elseif type(provider) == "table" then
+        opts = provider.opts
+        provider = providers[provider.name](winid, component, opts)
     end
 
     return provider, icon
@@ -237,7 +244,7 @@ local function parse_component(component, winid)
 
     if not enabled then return '' end
 
-    local str, icon = parse_provider(component.provider, component, winid)
+    local str, icon = parse_provider(component.provider, winid, component)
 
     local hl = evaluate_if_function(component.hl, winid) or {}
     local hlname

--- a/lua/feline/providers/cursor.lua
+++ b/lua/feline/providers/cursor.lua
@@ -2,11 +2,11 @@ local api = vim.api
 
 local M = {}
 
-function M.position(_, winid)
+function M.position(winid)
     return string.format('%3d:%-2d', unpack(api.nvim_win_get_cursor(winid)))
 end
 
-function M.line_percentage(_, winid)
+function M.line_percentage(winid)
     local curr_line = api.nvim_win_get_cursor(winid)[1]
     local lines = api.nvim_buf_line_count(api.nvim_win_get_buf(winid))
 
@@ -19,7 +19,7 @@ function M.line_percentage(_, winid)
     end
 end
 
-function M.scroll_bar(_, winid)
+function M.scroll_bar(winid)
     local blocks =  {'▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'}
     local width = 2
 

--- a/lua/feline/providers/file.lua
+++ b/lua/feline/providers/file.lua
@@ -70,24 +70,23 @@ local function get_unique_filename(filename, shorten)
     return string.reverse(string.sub(filename, 1, index))
 end
 
-function M.file_info(component, winid)
+function M.file_info(winid, component, opts)
     local filename = api.nvim_buf_get_name(api.nvim_win_get_buf(winid))
+    local type = opts.type or 'base-only'
 
-    component.type = component.type or 'base-only'
-
-    if component.type == 'short-path' then
+    if type == 'short-path' then
         filename = fn.pathshorten(filename)
-    elseif component.type == 'base-only' then
+    elseif type == 'base-only' then
         filename = fn.fnamemodify(filename, ':t')
-    elseif component.type == 'relative' then
+    elseif type == 'relative' then
         filename = fn.fnamemodify(filename, ":~:.")
-    elseif component.type == 'relative-short' then
+    elseif type == 'relative-short' then
         filename = fn.pathshorten(fn.fnamemodify(filename, ":~:."))
-    elseif component.type == 'unique' then
+    elseif type == 'unique' then
         filename = get_unique_filename(filename)
-    elseif component.type == 'unique-short' then
+    elseif type == 'unique-short' then
         filename = get_unique_filename(filename, true)
-    elseif component.type ~= 'full-path' then
+    elseif type ~= 'full-path' then
         filename = fn.fnamemodify(filename, ':t')
     end
 
@@ -104,7 +103,7 @@ function M.file_info(component, winid)
 
         icon = { str = icon_str }
 
-        if component.colored_icon == nil or component.colored_icon then
+        if opts.colored_icon == nil or opts.colored_icon then
             local fg = api.nvim_get_hl_by_name(icon_hlname, true).foreground
 
             if fg then
@@ -118,13 +117,13 @@ function M.file_info(component, winid)
     local bufnr = api.nvim_win_get_buf(winid)
 
     if bo[bufnr].readonly then
-        readonly_str = component.file_readonly_icon or '🔒'
+        readonly_str = opts.file_readonly_icon or '🔒'
     else
         readonly_str = ''
     end
 
     if bo[bufnr].modified then
-        modified_str = (component.file_modified_icon or '●')
+        modified_str = opts.file_modified_icon or '●'
 
         if modified_str ~= '' then modified_str = modified_str .. ' ' end
     else
@@ -134,7 +133,7 @@ function M.file_info(component, winid)
     return ' ' .. readonly_str .. filename .. ' ' .. modified_str, icon
 end
 
-function M.file_size(_, winid)
+function M.file_size(winid)
     local suffix = {'b', 'k', 'M', 'G', 'T', 'P', 'E'}
     local index = 1
 
@@ -150,11 +149,11 @@ function M.file_size(_, winid)
     return string.format(index == 1 and '%g' or '%.2f', fsize) .. suffix[index]
 end
 
-function M.file_type(_, winid)
+function M.file_type(winid)
     return bo[api.nvim_win_get_buf(winid)].filetype:upper()
 end
 
-function M.file_encoding(_, winid)
+function M.file_encoding(winid)
     local bufnr = api.nvim_win_get_buf(winid)
     local enc = (bo[bufnr].fenc ~= '' and bo[bufnr].fenc) or vim.o.enc
     return enc:upper()

--- a/lua/feline/providers/git.lua
+++ b/lua/feline/providers/git.lua
@@ -3,7 +3,7 @@ local api = vim.api
 
 local M = {}
 
-function M.git_branch(_, winid)
+function M.git_branch(winid)
     local ok, head = pcall(api.nvim_buf_get_var, api.nvim_win_get_buf(winid), 'gitsigns_head')
 
     if not ok then head = g.gitsigns_head or '' end
@@ -21,15 +21,15 @@ local function git_diff(winid, type)
     return ''
 end
 
-function M.git_diff_added(_, winid)
+function M.git_diff_added(winid)
     return git_diff(winid, 'added'), '  '
 end
 
-function M.git_diff_removed(_, winid)
+function M.git_diff_removed(winid)
     return git_diff(winid, 'removed'), '  '
 end
 
-function M.git_diff_changed(_, winid)
+function M.git_diff_changed(winid)
     return git_diff(winid, 'changed'),  ' 柳'
 end
 

--- a/lua/feline/providers/lsp.lua
+++ b/lua/feline/providers/lsp.lua
@@ -32,7 +32,7 @@ function M.diagnostics_exist(severity, bufnr)
     return diagnostics_count and diagnostics_count > 0
 end
 
-function M.lsp_client_names(_, winid)
+function M.lsp_client_names(winid)
     local clients = {}
 
     for _, client in pairs(lsp.buf_get_clients(api.nvim_win_get_buf(winid))) do
@@ -50,19 +50,19 @@ local function diagnostics(winid, severity)
     return tostring(count)
 end
 
-function M.diagnostic_errors(_, winid)
+function M.diagnostic_errors(winid)
     return diagnostics(winid, 'Error'), '  '
 end
 
-function M.diagnostic_warnings(_, winid)
+function M.diagnostic_warnings(winid)
     return diagnostics(winid, 'Warning'), '  '
 end
 
-function M.diagnostic_hints(_, winid)
+function M.diagnostic_hints(winid)
     return diagnostics(winid, 'Hint'), '  '
 end
 
-function M.diagnostic_info(_, winid)
+function M.diagnostic_info(winid)
     return diagnostics(winid, 'Information'), '  '
 end
 

--- a/lua/feline/providers/vi_mode.lua
+++ b/lua/feline/providers/vi_mode.lua
@@ -54,7 +54,7 @@ function M.get_mode_highlight_name()
     return 'StatusComponentVim' .. title_case(M.get_vim_mode())
 end
 
-function M.vi_mode(component)
+function M.vi_mode(_, component)
     if component.icon == '' then
         return M.get_vim_mode()
     elseif component.icon == nil then


### PR DESCRIPTION
BREAKING CHANGE: The arguments for provider functions have been changed.

Prerequisite for component truncation (#96). This seems to be working fine. Would still like a review from @ram02z 