### PR TITLE
refactor: re-add smart component truncation

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -164,6 +164,66 @@ end
 
 If you omit the provider value, it will be set to an empty string. A component with no provider or an empty provider may be useful for things like [applying a highlight to section gaps](#highlight-section-gaps) or just having an icon or separator as a component.
 
+#### Truncation
+
+Feline has an automatic smart truncation system where components can be automatically truncated if the statusline doesn't fit within the window. There's a few component values associated with truncation.
+
+##### Component short provider
+
+`short_provider` is an optional component value that allows you to take advantage of Feline's truncation system. Note that this should only be defined if you want to enable truncation for the component, otherwise it's absolutely fine to omit it.
+
+`short_provider` works just like the `provider` value, but is activated only when the component is being truncated due to the statusline not fitting within the window. `short_provider` is independent from the `provider` value so it can be a different provider altogether, or it can be a shortened version of the same provider or the same provider but with a different `opts` value. For example:
+
+```lua
+-- In this component, short provider uses same provider but with different opts
+local file_info_component = {
+    provider = {
+        name = 'file_info',
+        opts = {
+            type = 'full-path'
+        }
+    },
+    short_provider = {
+        name = 'file_info',
+        opts = {
+            type = 'short-path'
+        }
+    }
+}
+
+-- Short provider can also be an independent value / function
+local my_component = {
+    provider = 'loooooooooooooooong',
+    short_provider = 'short'
+}
+```
+
+Feline doesn't set `short_provider` to any component by default, so it must be provided manually.
+
+##### Hide components during truncation
+
+If you wish to allow Feline to hide a component entirely if necessary during truncation, you may set the `truncate_hide` component value to `true`. By default, `truncate_hide` is `false` for every component.
+
+##### Component priority
+
+When components are being truncated by Feline, you can choose to give some components a higher priority over the other components. The `priority` component value just takes a number. By default, the priority of a component is `0`. Components are truncated in ascending order of priority. So components with lower priority are truncated first, while components with higher priority are truncated later on. For example:
+
+```lua
+-- This component has the default priority
+local my_component = {
+    provider = 'loooooooooooooooong',
+    short_provider = 'short'
+}
+-- This component has a higher priority, so it will be truncated after the previous component
+local high_priority_component = {
+    provider = 'long provider with high priority',
+    short_provider = 'short',
+    priority = 1
+}
+```
+
+Priority can also be set to a negative number, which can be used to make a component be truncated earlier than the ones with default priority.
+
 #### Conditionally enable components
 
 The `enabled` value of a component can be a boolean or function. This value determines if the component is enabled or not. If false, the component is not shown in the statusline. For example:

--- a/lua/feline/statusline_ffi.lua
+++ b/lua/feline/statusline_ffi.lua
@@ -1,0 +1,72 @@
+-- This module provides an interface to Neovim's statusline generator using Lua FFI
+local M = {}
+
+local ffi = require('ffi')
+
+-- Definitions required to use Neovim's build_stl_str_hl function to expand statusline expressions
+-- And also other definitions used by this module
+ffi.cdef [[
+typedef unsigned char char_u;
+typedef struct window_S win_T;
+typedef struct {} stl_hlrec_t;
+typedef struct {} StlClickRecord;
+
+extern win_T *curwin;
+
+int build_stl_str_hl(
+    win_T *wp,
+    char_u *out,
+    size_t outlen,
+    char_u *fmt,
+    int use_sandbox,
+    char_u fillchar,
+    int maxwidth,
+    stl_hlrec_t **hltab,
+    StlClickRecord **tabtab
+);
+]]
+
+-- Used CType values stored in a local variable to avoid redefining them and improve performance
+local char_u_buf_t = ffi.typeof('char_u[?]')
+local char_u_str_t = ffi.typeof('char_u*')
+
+-- Statusline string buffer
+local stlbuf = char_u_buf_t(256)
+local stlbuf_len = 256
+
+-- Expand statusline expression, returns a Lua string containing plaintext with only the characters
+-- that'll be displayed in the statusline
+function M.expand_statusline_expr(expr)
+    ffi.C.build_stl_str_hl(
+        ffi.C.curwin,
+        stlbuf,
+        stlbuf_len,
+        ffi.cast(char_u_str_t, expr),
+        0,
+        0,
+        0,
+        nil,
+        nil
+    )
+
+    return ffi.string(stlbuf)
+end
+
+-- Get display width of statusline expression
+function M.get_statusline_expr_width(expr)
+    return tonumber(ffi.C.build_stl_str_hl(
+        ffi.C.curwin,
+        stlbuf,
+        stlbuf_len,
+        ffi.cast(char_u_str_t, expr),
+        0,
+        0,
+        0,
+        nil,
+        nil
+    ))
+end
+
+return M
+
+

--- a/lua/feline/statusline_ffi.lua
+++ b/lua/feline/statusline_ffi.lua
@@ -4,7 +4,6 @@ local M = {}
 local ffi = require('ffi')
 
 -- Definitions required to use Neovim's build_stl_str_hl function to expand statusline expressions
--- And also other definitions used by this module
 ffi.cdef [[
 typedef unsigned char char_u;
 typedef struct window_S win_T;
@@ -31,8 +30,8 @@ local char_u_buf_t = ffi.typeof('char_u[?]')
 local char_u_str_t = ffi.typeof('char_u*')
 
 -- Statusline string buffer
-local stlbuf = char_u_buf_t(256)
 local stlbuf_len = 256
+local stlbuf = char_u_buf_t(stlbuf_len)
 
 -- Expand statusline expression, returns a Lua string containing plaintext with only the characters
 -- that'll be displayed in the statusline
@@ -68,5 +67,3 @@ function M.get_statusline_expr_width(expr)
 end
 
 return M
-
-


### PR DESCRIPTION
Now fully supports VIm statusline expressions. Thanks to @shadmansaleh for assisting with the FFI code required for that. This should work perfectly fine. The only issue is that it causes a 53% performance downgrade, which is a pretty big issue. The downgrade is not really noticable to me but not sure about others. Not a fan of it using FFI to access Neovim's internals either, mostly because I don't have much knowledge about Neovim internals so it'd be a pain to troubleshoot a problem if the source of the problem is the FFI code.