### PR TITLE
refactor: evaluate providers in context of statusline window

### DIFF
--- a/lua/feline/defaults.lua
+++ b/lua/feline/defaults.lua
@@ -76,11 +76,4 @@ M.force_inactive = {
 
 M.disable = {}
 
-M.update_triggers = {
-    'VimEnter',
-    'WinEnter',
-    'WinClosed',
-    'FileChangedShellPost'
-}
-
 return M

--- a/lua/feline/providers/cursor.lua
+++ b/lua/feline/providers/cursor.lua
@@ -2,13 +2,15 @@ local api = vim.api
 
 local M = {}
 
-function M.position(winid)
-    return string.format('%3d:%-2d', unpack(api.nvim_win_get_cursor(winid)))
+local scroll_bar_blocks =  {'▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'}
+
+function M.position()
+    return string.format('%3d:%-2d', unpack(api.nvim_win_get_cursor(0)))
 end
 
-function M.line_percentage(winid)
-    local curr_line = api.nvim_win_get_cursor(winid)[1]
-    local lines = api.nvim_buf_line_count(api.nvim_win_get_buf(winid))
+function M.line_percentage()
+    local curr_line = api.nvim_win_get_cursor(0)[1]
+    local lines = api.nvim_buf_line_count(0)
 
     if curr_line == 1 then
         return "Top"
@@ -19,16 +21,11 @@ function M.line_percentage(winid)
     end
 end
 
-function M.scroll_bar(winid)
-    local blocks =  {'▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'}
-    local width = 2
+function M.scroll_bar()
+    local curr_line = api.nvim_win_get_cursor(0)[1]
+    local lines = api.nvim_buf_line_count(0)
 
-    local curr_line = api.nvim_win_get_cursor(winid)[1]
-    local lines = api.nvim_buf_line_count(api.nvim_win_get_buf(winid))
-
-    local index = math.floor(curr_line / lines * (#blocks - 1)) + 1
-
-    return string.rep(blocks[index], width)
+    return string.rep(scroll_bar_blocks[math.floor(curr_line / lines * 7) + 1], 2)
 end
 
 return M

--- a/lua/feline/providers/file.lua
+++ b/lua/feline/providers/file.lua
@@ -70,8 +70,8 @@ local function get_unique_filename(filename, shorten)
     return string.reverse(string.sub(filename, 1, index))
 end
 
-function M.file_info(winid, component, opts)
-    local filename = api.nvim_buf_get_name(api.nvim_win_get_buf(winid))
+function M.file_info(component, opts)
+    local filename = api.nvim_buf_get_name(0)
     local type = opts.type or 'base-only'
 
     if type == 'short-path' then
@@ -110,15 +110,13 @@ function M.file_info(winid, component, opts)
 
     if filename == '' then filename = 'unnamed' end
 
-    local bufnr = api.nvim_win_get_buf(winid)
-
-    if bo[bufnr].readonly then
+    if bo.readonly then
         readonly_str = opts.file_readonly_icon or '🔒'
     else
         readonly_str = ''
     end
 
-    if bo[bufnr].modified then
+    if bo.modified then
         modified_str = opts.file_modified_icon or '●'
 
         if modified_str ~= '' then modified_str = modified_str .. ' ' end
@@ -126,14 +124,14 @@ function M.file_info(winid, component, opts)
         modified_str = ''
     end
 
-    return ' ' .. readonly_str .. filename .. ' ' .. modified_str, icon
+    return string.format(' %s%s %s', readonly_str, filename, modified_str), icon
 end
 
-function M.file_size(winid)
+function M.file_size()
     local suffix = {'b', 'k', 'M', 'G', 'T', 'P', 'E'}
     local index = 1
 
-    local fsize = fn.getfsize(api.nvim_buf_get_name(api.nvim_win_get_buf(winid)))
+    local fsize = fn.getfsize(api.nvim_buf_get_name(0))
 
     if fsize < 0 then fsize = 0 end
 
@@ -142,17 +140,15 @@ function M.file_size(winid)
         index = index + 1
     end
 
-    return string.format(index == 1 and '%g' or '%.2f', fsize) .. suffix[index]
+    return string.format(index == 1 and '%g%s' or '%.2f%s', fsize, suffix[index])
 end
 
-function M.file_type(winid)
-    return bo[api.nvim_win_get_buf(winid)].filetype:upper()
+function M.file_type()
+    return bo.filetype:upper()
 end
 
-function M.file_encoding(winid)
-    local bufnr = api.nvim_win_get_buf(winid)
-    local enc = (bo[bufnr].fenc ~= '' and bo[bufnr].fenc) or vim.o.enc
-    return enc:upper()
+function M.file_encoding()
+    return ((bo.fenc ~= '' and bo.fenc) or vim.o.enc):upper()
 end
 
 return M

--- a/lua/feline/providers/git.lua
+++ b/lua/feline/providers/git.lua
@@ -1,43 +1,38 @@
+local b = vim.b
 local g = vim.g
-local api = vim.api
 
 local M = {}
 
-function M.git_branch(winid)
-    local ok, head = pcall(api.nvim_buf_get_var, api.nvim_win_get_buf(winid), 'gitsigns_head')
-
-    if not ok then head = g.gitsigns_head or '' end
-    return head, ' '
+function M.git_branch()
+    return b.gitsigns_head or g.gitsigns_head or '', ' '
 end
 
 -- Common function used by the git providers
-local function git_diff(winid, type)
-    local ok, gsd = pcall(api.nvim_buf_get_var, api.nvim_win_get_buf(winid), 'gitsigns_status_dict')
+local function git_diff(type)
+    local gsd = b.gitsigns_status_dict
 
-    if ok and gsd[type] and gsd[type] > 0 then
+    if gsd and gsd[type] and gsd[type] > 0 then
         return tostring(gsd[type])
     end
 
     return ''
 end
 
-function M.git_diff_added(winid)
-    return git_diff(winid, 'added'), '  '
+function M.git_diff_added()
+    return git_diff('added'), '  '
 end
 
-function M.git_diff_removed(winid)
-    return git_diff(winid, 'removed'), '  '
+function M.git_diff_removed()
+    return git_diff('removed'), '  '
 end
 
-function M.git_diff_changed(winid)
-    return git_diff(winid, 'changed'),  ' 柳'
+function M.git_diff_changed()
+    return git_diff('changed'),  ' 柳'
 end
 
 -- Utility function to check if git provider information is available
-function M.git_info_exists(winid)
-    return g.gitsigns_head or
-        pcall(api.nvim_buf_get_var, api.nvim_win_get_buf(winid), 'gitsigns_head') or
-        pcall(api.nvim_buf_get_var, api.nvim_win_get_buf(winid), 'gitsigns_status_dict')
+function M.git_info_exists()
+    return g.gitsigns_head or b.gitsigns_head or b.gitsigns_status_dict
 end
 
 return M

--- a/lua/feline/providers/lsp.lua
+++ b/lua/feline/providers/lsp.lua
@@ -1,41 +1,33 @@
 local M = {}
 
-local api = vim.api
 local lsp = vim.lsp
 
-function M.is_lsp_attached(bufnr)
-    bufnr = bufnr or api.nvim_get_current_buf()
-
-    return next(lsp.buf_get_clients(bufnr)) ~= nil
+function M.is_lsp_attached()
+    return next(lsp.buf_get_clients(0)) ~= nil
 end
 
-function M.get_diagnostics_count(severity, bufnr)
-    bufnr = bufnr or api.nvim_get_current_buf()
+function M.get_diagnostics_count(severity)
+    local active_clients = lsp.buf_get_clients(0)
 
-    local active_clients = lsp.buf_get_clients(bufnr)
-
-    if not active_clients then return nil end
+    if not active_clients then return 0 end
 
     local count = 0
 
     for _, client in pairs(active_clients) do
-        count = count + lsp.diagnostic.get_count(bufnr, severity, client.id)
+        count = count + lsp.diagnostic.get_count(0, severity, client.id)
     end
 
     return count
 end
 
-function M.diagnostics_exist(severity, bufnr)
-    bufnr = bufnr or api.nvim_get_current_buf()
-
-    local diagnostics_count = M.get_diagnostics_count(severity, bufnr)
-    return diagnostics_count and diagnostics_count > 0
+function M.diagnostics_exist(severity)
+    return M.get_diagnostics_count(severity) > 0
 end
 
-function M.lsp_client_names(winid)
+function M.lsp_client_names()
     local clients = {}
 
-    for _, client in pairs(lsp.buf_get_clients(api.nvim_win_get_buf(winid))) do
+    for _, client in pairs(lsp.buf_get_clients(0)) do
         clients[#clients+1] = client.name
     end
 
@@ -43,27 +35,26 @@ function M.lsp_client_names(winid)
 end
 
 -- Common function used by the diagnostics providers
-local function diagnostics(winid, severity)
-    local count = M.get_diagnostics_count(severity, api.nvim_win_get_buf(winid))
+local function diagnostics(severity)
+    local count = M.get_diagnostics_count(severity)
 
-    if not count or count == 0 then return '' end
-    return tostring(count)
+    return count ~= 0 and tostring(count) or ''
 end
 
-function M.diagnostic_errors(winid)
-    return diagnostics(winid, 'Error'), '  '
+function M.diagnostic_errors()
+    return diagnostics('Error'), '  '
 end
 
-function M.diagnostic_warnings(winid)
-    return diagnostics(winid, 'Warning'), '  '
+function M.diagnostic_warnings()
+    return diagnostics('Warning'), '  '
 end
 
-function M.diagnostic_hints(winid)
-    return diagnostics(winid, 'Hint'), '  '
+function M.diagnostic_hints()
+    return diagnostics('Hint'), '  '
 end
 
-function M.diagnostic_info(winid)
-    return diagnostics(winid, 'Information'), '  '
+function M.diagnostic_info()
+    return diagnostics('Information'), '  '
 end
 
 return M

--- a/lua/feline/providers/vi_mode.lua
+++ b/lua/feline/providers/vi_mode.lua
@@ -54,7 +54,7 @@ function M.get_mode_highlight_name()
     return 'StatusComponentVim' .. title_case(M.get_vim_mode())
 end
 
-function M.vi_mode(_, component)
+function M.vi_mode(component)
     if component.icon == '' then
         return M.get_vim_mode()
     elseif component.icon == nil then


### PR DESCRIPTION
BREAKING CHANGE: The statusline providers no longer take a `winid` argument. Now you need to use `vim.api.nvim_get_current_win()` to get the statusline window and `vim.api.nvim_get_current_buf()` for the statusline buffer. For the actual current window / buffer, you need to use `vim.g.actual_curwin` and `vim.g.actual_curbuf`, respectively.  As a result of this change, the `update_triggers` option has also been removed.

Still need to add docs before I can merge this