### PR TITLE
feat: make components table linear

### DIFF
--- a/lua/feline/presets/default.lua
+++ b/lua/feline/presets/default.lua
@@ -1,176 +1,167 @@
 local vi_mode_utils = require('feline.providers.vi_mode')
 
-local M = {
-    active = {},
-    inactive = {}
-}
-
-M.active[1] = {
-    {
-        provider = '▊ ',
-        hl = {
-            fg = 'skyblue'
-        }
-    },
-    {
-        provider = 'vi_mode',
-        hl = function()
-            return {
-                name = vi_mode_utils.get_mode_highlight_name(),
-                fg = vi_mode_utils.get_mode_color(),
+return {
+    active = {
+        {
+            provider = '▊ ',
+            hl = {
+                fg = 'skyblue'
+            }
+        },
+        {
+            provider = 'vi_mode',
+            hl = function()
+                return {
+                    name = vi_mode_utils.get_mode_highlight_name(),
+                    fg = vi_mode_utils.get_mode_color(),
+                    style = 'bold'
+                }
+            end,
+            right_sep = ' '
+        },
+        {
+            provider = 'file_info',
+            hl = {
+                fg = 'white',
+                bg = 'oceanblue',
+                style = 'bold'
+            },
+            left_sep = {
+                ' ', 'slant_left_2',
+                {str = ' ', hl = {bg = 'oceanblue', fg = 'NONE'}}
+            },
+            right_sep = {'slant_right_2', ' '}
+        },
+        {
+            provider = 'file_size',
+            right_sep = {
+                ' ',
+                {
+                    str = 'slant_left_2_thin',
+                    hl = {
+                        fg = 'fg',
+                        bg = 'bg'
+                    }
+                },
+            }
+        },
+        {
+            provider = 'position',
+            left_sep = ' ',
+            right_sep = {
+                ' ',
+                {
+                    str = 'slant_right_2_thin',
+                    hl = {
+                        fg = 'fg',
+                        bg = 'bg'
+                    }
+                }
+            }
+        },
+        {
+            provider = 'diagnostic_errors',
+            hl = { fg = 'red' }
+        },
+        {
+            provider = 'diagnostic_warnings',
+            hl = { fg = 'yellow' }
+        },
+        {
+            provider = 'diagnostic_hints',
+            hl = { fg = 'cyan' }
+        },
+        {
+            provider = 'diagnostic_info',
+            hl = { fg = 'skyblue' }
+        },
+        {
+            provider = 'spacer'
+        },
+        {
+            provider = 'git_branch',
+            hl = {
+                fg = 'white',
+                bg = 'black',
+                style = 'bold'
+            },
+            right_sep = {
+                str = ' ',
+                hl = {
+                    fg = 'NONE',
+                    bg = 'black'
+                }
+            }
+        },
+        {
+            provider = 'git_diff_added',
+            hl = {
+                fg = 'green',
+                bg = 'black'
+            }
+        },
+        {
+            provider = 'git_diff_changed',
+            hl = {
+                fg = 'orange',
+                bg = 'black'
+            }
+        },
+        {
+            provider = 'git_diff_removed',
+            hl = {
+                fg = 'red',
+                bg = 'black'
+            },
+            right_sep = {
+                str = ' ',
+                hl = {
+                    fg = 'NONE',
+                    bg = 'black'
+                }
+            }
+        },
+        {
+            provider = 'line_percentage',
+            hl = {
+                style = 'bold'
+            },
+            left_sep = '  ',
+            right_sep = ' '
+        },
+        {
+            provider = 'scroll_bar',
+            hl = {
+                fg = 'skyblue',
                 style = 'bold'
             }
-        end,
-        right_sep = ' '
+        }
     },
-    {
-        provider = 'file_info',
-        hl = {
-            fg = 'white',
-            bg = 'oceanblue',
-            style = 'bold'
-        },
-        left_sep = {
-            ' ', 'slant_left_2',
-            {str = ' ', hl = {bg = 'oceanblue', fg = 'NONE'}}
-        },
-        right_sep = {'slant_right_2', ' '}
-    },
-    {
-        provider = 'file_size',
-        right_sep = {
-            ' ',
-            {
-                str = 'slant_left_2_thin',
-                hl = {
-                    fg = 'fg',
-                    bg = 'bg'
-                }
+    inactive = {
+        {
+            provider = 'file_type',
+            hl = {
+                fg = 'white',
+                bg = 'oceanblue',
+                style = 'bold'
             },
-        }
-    },
-    {
-        provider = 'position',
-        left_sep = ' ',
-        right_sep = {
-            ' ',
-            {
-                str = 'slant_right_2_thin',
-                hl = {
-                    fg = 'fg',
-                    bg = 'bg'
-                }
-            }
-        }
-    },
-    {
-        provider = 'diagnostic_errors',
-        hl = { fg = 'red' }
-    },
-    {
-        provider = 'diagnostic_warnings',
-        hl = { fg = 'yellow' }
-    },
-    {
-        provider = 'diagnostic_hints',
-        hl = { fg = 'cyan' }
-    },
-    {
-        provider = 'diagnostic_info',
-        hl = { fg = 'skyblue' }
-    }
-}
-
-M.active[2] = {
-    {
-        provider = 'git_branch',
-        hl = {
-            fg = 'white',
-            bg = 'black',
-            style = 'bold'
-        },
-        right_sep = {
-            str = ' ',
-            hl = {
-                fg = 'NONE',
-                bg = 'black'
-            }
-        }
-    },
-    {
-        provider = 'git_diff_added',
-        hl = {
-            fg = 'green',
-            bg = 'black'
-        }
-    },
-    {
-        provider = 'git_diff_changed',
-        hl = {
-            fg = 'orange',
-            bg = 'black'
-        }
-    },
-    {
-        provider = 'git_diff_removed',
-        hl = {
-            fg = 'red',
-            bg = 'black'
-        },
-        right_sep = {
-            str = ' ',
-            hl = {
-                fg = 'NONE',
-                bg = 'black'
-            }
-        }
-    },
-    {
-        provider = 'line_percentage',
-        hl = {
-            style = 'bold'
-        },
-        left_sep = '  ',
-        right_sep = ' '
-    },
-    {
-        provider = 'scroll_bar',
-        hl = {
-            fg = 'skyblue',
-            style = 'bold'
-        }
-    }
-}
-
-M.inactive[1] = {
-    {
-        provider = 'file_type',
-        hl = {
-            fg = 'white',
-            bg = 'oceanblue',
-            style = 'bold'
-        },
-        left_sep = {
-            str = ' ',
-            hl = {
-                fg = 'NONE',
-                bg = 'oceanblue'
-            }
-        },
-        right_sep = {
-            {
+            left_sep = {
                 str = ' ',
                 hl = {
                     fg = 'NONE',
                     bg = 'oceanblue'
                 }
             },
-            'slant_right'
-        }
-    },
-    -- Empty component to fix the highlight till the end of the statusline
-    {
+            right_sep = {
+                {
+                    str = ' ',
+                    hl = {
+                        fg = 'NONE',
+                        bg = 'oceanblue'
+                    }
+                },
+                'slant_right'
+            }
+        },
     }
 }
-
-return M

--- a/lua/feline/presets/noicon.lua
+++ b/lua/feline/presets/noicon.lua
@@ -1,183 +1,174 @@
 local vi_mode_utils = require('feline.providers.vi_mode')
 
-local M = {
-    active = {},
-    inactive = {}
-}
-
-M.active[1] = {
-    {
-        provider = '▊ ',
-        hl = {
-            fg = 'skyblue'
-        }
-    },
-    {
-        provider = 'vi_mode',
-        hl = function()
-            return {
-                name = vi_mode_utils.get_mode_highlight_name(),
-                fg = vi_mode_utils.get_mode_color(),
-                style = 'bold'
+return {
+    active = {
+        {
+            provider = '▊ ',
+            hl = {
+                fg = 'skyblue'
             }
-        end,
-        right_sep = ' ',
-        icon = ''
-    },
-    {
-        provider = 'file_info',
-        hl = {
-            fg = 'white',
-            bg = 'oceanblue',
-            style = 'bold'
         },
-        left_sep = '',
-        right_sep = ' ',
-        icon = ''
-    },
-    {
-        provider = 'file_size',
-        right_sep = {
-            ' ',
-            {
-                str = 'vertical_bar_thin',
+        {
+            provider = 'vi_mode',
+            hl = function()
+                return {
+                    name = vi_mode_utils.get_mode_highlight_name(),
+                    fg = vi_mode_utils.get_mode_color(),
+                    style = 'bold'
+                }
+            end,
+            right_sep = ' ',
+            icon = ''
+        },
+        {
+            provider = 'file_info',
+            hl = {
+                fg = 'white',
+                bg = 'oceanblue',
+                style = 'bold'
+            },
+            left_sep = '',
+            right_sep = ' ',
+            icon = ''
+        },
+        {
+            provider = 'file_size',
+            right_sep = {
+                ' ',
+                {
+                    str = 'vertical_bar_thin',
+                    hl = {
+                        fg = 'fg',
+                        bg = 'bg'
+                    }
+                },
+            }
+        },
+        {
+            provider = 'position',
+            left_sep = ' ',
+            right_sep = {
+                ' ',
+                {
+                    str = 'vertical_bar_thin',
+                    hl = {
+                        fg = 'fg',
+                        bg = 'bg'
+                    }
+                }
+            }
+        },
+        {
+            provider = 'diagnostic_errors',
+            hl = { fg = 'red' },
+            icon = ' E-'
+        },
+        {
+            provider = 'diagnostic_warnings',
+            hl = { fg = 'yellow' },
+            icon = ' W-'
+        },
+        {
+            provider = 'diagnostic_hints',
+            hl = { fg = 'cyan' },
+            icon = ' H-'
+        },
+        {
+            provider = 'diagnostic_info',
+            hl = { fg = 'skyblue' },
+            icon = ' I-'
+        },
+        {
+            provider = 'spacer'
+        },
+        {
+            provider = 'git_branch',
+            hl = {
+                fg = 'white',
+                bg = 'black',
+                style = 'bold'
+            },
+            right_sep = {
+                str = ' ',
                 hl = {
-                    fg = 'fg',
-                    bg = 'bg'
+                    fg = 'NONE',
+                    bg = 'black'
                 }
             },
-        }
-    },
-    {
-        provider = 'position',
-        left_sep = ' ',
-        right_sep = {
-            ' ',
-            {
-                str = 'vertical_bar_thin',
+            icon = ' '
+        },
+        {
+            provider = 'git_diff_added',
+            hl = {
+                fg = 'green',
+                bg = 'black'
+            },
+            icon = ' +'
+        },
+        {
+            provider = 'git_diff_changed',
+            hl = {
+                fg = 'orange',
+                bg = 'black'
+            },
+            icon = ' ~'
+        },
+        {
+            provider = 'git_diff_removed',
+            hl = {
+                fg = 'red',
+                bg = 'black'
+            },
+            right_sep = {
+                str = ' ',
                 hl = {
-                    fg = 'fg',
-                    bg = 'bg'
+                    fg = 'NONE',
+                    bg = 'black'
                 }
+            },
+            icon = ' -'
+        },
+        {
+            provider = 'line_percentage',
+            hl = {
+                style = 'bold'
+            },
+            left_sep = '  ',
+            right_sep = ' '
+        },
+        {
+            provider = 'scroll_bar',
+            hl = {
+                fg = 'skyblue',
+                style = 'bold'
             }
         }
     },
-    {
-        provider = 'diagnostic_errors',
-        hl = { fg = 'red' },
-        icon = ' E-'
-    },
-    {
-        provider = 'diagnostic_warnings',
-        hl = { fg = 'yellow' },
-        icon = ' W-'
-    },
-    {
-        provider = 'diagnostic_hints',
-        hl = { fg = 'cyan' },
-        icon = ' H-'
-    },
-    {
-        provider = 'diagnostic_info',
-        hl = { fg = 'skyblue' },
-        icon = ' I-'
-    }
-}
-
-M.active[2] = {
-    {
-        provider = 'git_branch',
-        hl = {
-            fg = 'white',
-            bg = 'black',
-            style = 'bold'
-        },
-        right_sep = {
-            str = ' ',
+    inactive = {
+        {
+            provider = 'file_type',
             hl = {
-                fg = 'NONE',
-                bg = 'black'
-            }
-        },
-        icon = ' '
-    },
-    {
-        provider = 'git_diff_added',
-        hl = {
-            fg = 'green',
-            bg = 'black'
-        },
-        icon = ' +'
-    },
-    {
-        provider = 'git_diff_changed',
-        hl = {
-            fg = 'orange',
-            bg = 'black'
-        },
-        icon = ' ~'
-    },
-    {
-        provider = 'git_diff_removed',
-        hl = {
-            fg = 'red',
-            bg = 'black'
-        },
-        right_sep = {
-            str = ' ',
-            hl = {
-                fg = 'NONE',
-                bg = 'black'
-            }
-        },
-        icon = ' -'
-    },
-    {
-        provider = 'line_percentage',
-        hl = {
-            style = 'bold'
-        },
-        left_sep = '  ',
-        right_sep = ' '
-    },
-    {
-        provider = 'scroll_bar',
-        hl = {
-            fg = 'skyblue',
-            style = 'bold'
-        }
-    }
-}
-
-M.inactive[1] = {
-    {
-        provider = 'file_type',
-        hl = {
-            fg = 'white',
-            bg = 'oceanblue',
-            style = 'bold'
-        },
-        left_sep = {
-            str = ' ',
-            hl = {
-                fg = 'NONE',
-                bg = 'oceanblue'
-            }
-        },
-        right_sep = {
-            {
+                fg = 'white',
+                bg = 'oceanblue',
+                style = 'bold'
+            },
+            left_sep = {
                 str = ' ',
                 hl = {
                     fg = 'NONE',
                     bg = 'oceanblue'
                 }
             },
-            ' '
-        }
-    },
-    -- Empty component to fix the highlight till the end of the statusline
-    {
+            right_sep = {
+                {
+                    str = ' ',
+                    hl = {
+                        fg = 'NONE',
+                        bg = 'oceanblue'
+                    }
+                },
+                ' '
+            }
+        },
     }
 }
-
-return M

--- a/lua/feline/providers/init.lua
+++ b/lua/feline/providers/init.lua
@@ -7,6 +7,7 @@ local provider_categories = {
     file = lazy_require('feline.providers.file'),
     lsp = lazy_require('feline.providers.lsp'),
     git = lazy_require('feline.providers.git'),
+    misc = lazy_require('feline.providers.misc'),
     custom = {}
 }
 
@@ -32,7 +33,9 @@ local get_provider_category = {
     diagnostic_errors = 'lsp',
     diagnostic_warnings = 'lsp',
     diagnostic_hints = 'lsp',
-    diagnostic_info = 'lsp'
+    diagnostic_info = 'lsp',
+
+    spacer = 'misc'
 }
 
 -- Providers that have been loaded

--- a/lua/feline/providers/misc.lua
+++ b/lua/feline/providers/misc.lua
@@ -1,0 +1,8 @@
+local M = {}
+
+-- Creates a new statusline section
+function M.spacer()
+    return '%='
+end
+
+return M


### PR DESCRIPTION
Instead of having the components table contain a list of sections which in turn contain a list of components, make the components table contain a list of components directly and turn the section separator into a provider named `spacer`. This greatly enhances the configuration capabilities of Feline by making section gaps and their highlighting more explicit, while also allowing for section gaps to use the `default_hl` value by default. It also greatly simplifies the truncation code.

Need to add docs before it can be merged. Still not 100% sure if making the components table linear is a good idea though