### PR TITLE
Add mode alias for "nt"

### DIFF
--- a/lua/feline/providers/vi_mode.lua
+++ b/lua/feline/providers/vi_mode.lua
@@ -11,6 +11,7 @@ local mode_alias = {
     ['niI'] = 'NORMAL',
     ['niR'] = 'NORMAL',
     ['niV'] = 'NORMAL',
+    ['nt'] = 'NORMAL',
     ['v'] = 'VISUAL',
     ['V'] = 'LINES',
     [''] = 'BLOCK',


### PR DESCRIPTION
This function was broken by https://github.com/neovim/neovim/commit/f4359b5dbdd5ed9aa230532382edd7eb6cd0a61b which let `nvim_get_mode` return "nt" if in normal mode in term