### PR TITLE
Feature: allows to specify a highlight group as a color

### DIFF
--- a/lua/feline/generator.lua
+++ b/lua/feline/generator.lua
@@ -60,6 +60,22 @@ local function add_hl(name, fg, bg, style)
     M.highlights[name] = true
 end
 
+-- Resolves color_or_hl depending on its content. 
+-- 
+-- @param color_or_hl String with or hex color '#xxxxxx', or name of highlight group.
+-- @param what        Which exactly color should be used in case of highlight group:
+--                    - 'foreground' to take a foreground color; 
+--                    - 'background' to take a background color.
+local function resolve_color(color_or_hl, what)
+    if (color_or_hl:sub(1, 1) == '#') or (vim.fn.hlID(color_or_hl) == 0)  then
+        return color_or_hl
+    end
+
+    local hl = vim.api.nvim_get_hl_by_name(color_or_hl, true)
+
+    return hl[what] and string.format('#%06x', hl[what]) or color_or_hl
+end
+
 -- Parse highlight table, inherit default/parent values if values are not given
 local function parse_hl(hl, parent_hl)
     parent_hl = parent_hl or {}
@@ -72,8 +88,8 @@ local function parse_hl(hl, parent_hl)
     if feline.colors[bg] then bg = feline.colors[bg] end
 
     return {
-        fg = fg,
-        bg = bg,
+        fg = resolve_color(fg, 'foreground'),
+        bg = resolve_color(bg, 'background'),
         style = style
     }
 end


### PR DESCRIPTION
This PR gives the ability to specify a color from existing highlight groups. It should help to create a status line that will use colors from the current `colorscheme`. 

For example, let's set 'Keyword' foreground color as the `fg` color in the theme of feline:

```lua
    use({
        'famiu/feline.nvim',
        config = function()
            local colors = require('feline.themes').default
            colors.fg = 'Keyword'
            require('feline').setup({
                theme = colors,
                components = require('feline.presets')['noicon']
            })
        end,
    })
```
Now, I have two schemes: `nightfox` <img width="279" alt="Screenshot 2021-11-16 at 10 19 29" src="https://user-images.githubusercontent.com/6939832/141938988-3c449413-6ea3-4202-a73c-c56669afe74c.png"> 
and `onehalfdark` <img width="379" alt="Screenshot 2021-11-16 at 10 19 54" src="https://user-images.githubusercontent.com/6939832/141939033-23da6d99-9792-4a9d-a5e7-d844318ef3dc.png">

So, the statusline will look different, depending on which scheme is used:

`nightfox`:  <img width="397" alt="Screenshot 2021-11-16 at 10 23 42" src="https://user-images.githubusercontent.com/6939832/141939457-88eb5a95-bac3-4c38-84cf-cfa70a1cf119.png">

`onehalfdark`: <img width="398" alt="Screenshot 2021-11-16 at 10 23 23" src="https://user-images.githubusercontent.com/6939832/141939491-f3c6907a-ad1f-4faa-a790-32757bf93333.png">


related to #164 