### PR TITLE
feat: add winbar autocmd option

### DIFF
--- a/lua/feline/defaults.lua
+++ b/lua/feline/defaults.lua
@@ -115,5 +115,19 @@ return {
         conditional_components = {
             type = 'table',
         },
+        use_autocmd = {
+            type = 'boolean',
+            default_value = false,
+        },
+        autocmd_triggers = {
+            type = 'table',
+            default_value = {
+                'CursorMoved',
+                'BufWinEnter',
+                'BufFilePost',
+                'InsertEnter',
+                'BufWritePost',
+            },
+        },
     },
 }

--- a/lua/feline/init.lua
+++ b/lua/feline/init.lua
@@ -204,7 +204,24 @@ function M.winbar.setup(config)
         winbar_gen:clear_state()
     end
 
-    vim.o.winbar = "%{%v:lua.require'feline'.generate_winbar()%}"
+    if config.use_autocmd then
+        utils.create_augroup({
+            {
+                event = config.autocmd_triggers,
+                opts = {
+                    callback = function()
+                        local content = require('feline').generate_winbar()
+                        local status_ok, _ = pcall(api.nvim_set_option_value, "winbar", content, { scope = "local" })
+                        if not status_ok then
+                            return
+                        end
+                    end,
+                }
+            }
+        }, 'feline')
+    else
+        vim.o.winbar = "%{%v:lua.require'feline'.generate_winbar()%}"
+    end
 end
 
 function M.generate_statusline()


### PR DESCRIPTION
-> Allow autocmd winbar option as a workaround in order to actually disable winbar on a per-window basis.

Indeed there was an issues some time ago: #319. I agree that autocmd is an antipattern, but until we have native support, I think it's useful to have this as a temporary solution. It's very annoying to have winbar on NvimTree and qf windows.
